### PR TITLE
Update ultraman to v0.1.1

### DIFF
--- a/Formula/ultraman.rb
+++ b/Formula/ultraman.rb
@@ -1,27 +1,25 @@
 # https://qiita.com/dalance/items/b07bee6cadfd4dd19756
 class Ultraman < Formula
-  version '0.1.0'
+  version '0.1.1'
   desc "Manage Procfile-based applications. (Rust Foreman)"
   homepage "https://github.com/yukihirop/ultraman"
 
   depends_on "rust" => :build
   
   if OS.mac?
-    url "https://github.com/yukihirop/ultraman/releases/download/v0.1.0/ultraman-v0.1.0-x86_64-mac.zip"
-    sha256 '806358564886618e29767a4fab1b1e1456ff1fe5bc496ae9908968b68c5fee64'
+    url "https://github.com/yukihirop/ultraman/releases/download/v0.1.1/ultraman-v0.1.1-x86_64-mac.zip"
+    sha256 'f352b307c3c16ddf4685964495642b94be8caf01fe21ca1a40b80eae26d6f238'
   end
 
   if OS.linux?
-    url "https://github.com/yukihirop/ultraman/releases/download/v0.1.0/ultraman-v0.1.0-x86_64-linux.zip"
-    sha256 '9123ae1fd343c1d7a1641e6c5fd8b513d901b50894a37d5977c9f11f794d2931'
+    url "https://github.com/yukihirop/ultraman/releases/download/v0.1.1/ultraman-v0.1.1-x86_64-linux.zip"
+    sha256 'be19d95b1dc4e2f099aecb9cd2deb96cd1ed2112ba4ebde4fc72af2c1645b2b8'
   end
 
   head 'https://github.com/yukihirop/ultraman.git'
 
   def install
-    if build.head?
-      system 'make', 'install_man'
-    end
+    man1.install 'ultraman.1'
     bin.install 'ultraman'
   end
 end


### PR DESCRIPTION
### Summary

- bump v0.1.1
- Install man

### Work

```bash
$ brew install ultraman
Updating Homebrew...
==> Auto-updated Homebrew!
Updated 1 tap (homebrew/core).
==> Updated Formulae
Updated 2 formulae.

==> Installing ultraman from yukihirop/tap
==> Downloading https://github.com/yukihirop/ultraman/releases/download/v0.1.1/ultraman-v0.1.1-x86_64-mac.zip
Already downloaded: /Users/yukihirop/Library/Caches/Homebrew/downloads/b5be688cbbfcb663476f356962e6437719c93c9813b9f71a9d42287f3f159af6--ultraman-v0.1.1-x86_64-mac.zip
Warning: Your Xcode (10.2.1) is outdated.
Please update to Xcode 11.3.1 (or delete it).
Xcode can be updated from the App Store.

Warning: A newer Command Line Tools release is available.
Update them from Software Update in System Preferences or run:
  softwareupdate --all --install --force

If that doesn't show you an update run:
  sudo rm -rf /Library/Developer/CommandLineTools
  sudo xcode-select --install

Alternatively, manually download them from:
  https://developer.apple.com/download/more/.

🍺  /usr/local/Cellar/ultraman/0.1.0: 6 files, 3.4MB, built in 6 seconds
(⎈ |minikube:default)#2020-12-24 19:04|yukihirop@FukudanoMacBook-Pro:~/RustProjects/ultraman (main?)
$ man ultraman
(⎈ |minikube:default)#2020-12-24 19:05|yukihirop@FukudanoMacBook-Pro:~/RustProjects/ultraman (main?)
$ which ultraman
/usr/local/bin/ultraman
```